### PR TITLE
chore: Setting up Github CI

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,23 @@
+name: Android CI
+
+on: push
+    
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: set up JDK 1.8
+
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+
+    - name: Giving Permission for Accessing Gradle file
+      run: chmod +x ./collectous/gradlew
+
+    - name: Compiling Project using Gradle
+      run: ./collectous/gradlew build

--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
 # Collectous
 
+![Android CI](https://github.com/ANUHisoc/nasio-data-collection-app/workflows/Android%20CI/badge.svg?branch=main)
 ![Status](https://img.shields.io/badge/status-work--in--progress-red)
 
 ## Table of content:
 - [Description](#-description)
-- [Documentation](#)
+- [Documentation](#-documentation)
 - [Tools used](#%EF%B8%8F-tools-used)
+- [References/Credits](#-referencescredits)
 - [Installation](#%EF%B8%8F-installation)
 
 
 
 ### 📜 Description:
-
+A simple household based data collection Android application which uses Google Sheets as it's cloud storage.
 
 ### 📒 Documentation:
 -   [Product Backlog]()


### PR DESCRIPTION
chore:
Setting up Github CI so that everytime a code change is pushed it is evident that the project is compile worthy.

docs(README):
Adding Github CI status bar.
Linked local hyperlinks
